### PR TITLE
Make the debug message a bit more descriptive

### DIFF
--- a/nova/scheduler/filters/pci_passthrough_filter.py
+++ b/nova/scheduler/filters/pci_passthrough_filter.py
@@ -51,6 +51,6 @@ class PciPassthroughFilter(filters.BaseHostFilter):
             not host_state.pci_stats.support_requests(pci_requests.requests)):
             LOG.debug("%(host_state)s doesn't have the required PCI devices"
                       " (%(requests)s)",
-                      {'host_state': host_state, 'requests': pci_requests})
+                      {'host_state': host_state, 'requests': pci_requests.requests})
             return False
         return True


### PR DESCRIPTION
As it stands, the original debug message would list the instance pci request as

```(InstancePCIRequests(instance_uuid=417592b3-71a1-485a-8209-a7e01fc7ad32,requests=[InstancePCIRequest]))```

If we replace `pci_requests` with `pci_requests.requests` it would list the request closer to what is being shown in the documentation on the top of the file, e.g.

```([InstancePCIRequest(alias_name='Netronome',count=1,is_new=<?>,numa_policy='legacy',request_id=None,requester_id=<?>,spec=[{dev_type='type-PCI',product_id='4000',vendor_id='19ee'}])])```